### PR TITLE
feat : 협력 프로젝트 수정/조회 기능 구현

### DIFF
--- a/src/main/java/com/epris/homepage/activity/corporate_project/controller/CorporateProjectController.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/controller/CorporateProjectController.java
@@ -1,0 +1,26 @@
+package com.epris.homepage.activity.corporate_project.controller;
+
+
+import com.epris.homepage.activity.corporate_project.dto.CorporateProjectRequestDto;
+import com.epris.homepage.activity.corporate_project.dto.CorporateProjectResponseDto;
+import com.epris.homepage.activity.corporate_project.service.CorporateProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/corporate-project")
+public class CorporateProjectController {
+    private final CorporateProjectService corporateProjectService;
+
+    @PostMapping
+    public ResponseEntity<CorporateProjectResponseDto> updateCorporateProject(@RequestBody CorporateProjectRequestDto requestDto) throws IOException {
+        return corporateProjectService.updateCorporateProject(requestDto);
+    }
+}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/controller/CorporateProjectController.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/controller/CorporateProjectController.java
@@ -6,10 +6,7 @@ import com.epris.homepage.activity.corporate_project.dto.CorporateProjectRespons
 import com.epris.homepage.activity.corporate_project.service.CorporateProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
 
@@ -22,5 +19,10 @@ public class CorporateProjectController {
     @PostMapping
     public ResponseEntity<CorporateProjectResponseDto> updateCorporateProject(@RequestBody CorporateProjectRequestDto requestDto) throws IOException {
         return corporateProjectService.updateCorporateProject(requestDto);
+    }
+
+    @GetMapping
+    public ResponseEntity<CorporateProjectResponseDto> findCorporateProject(){
+        return corporateProjectService.findCorporateProject();
     }
 }

--- a/src/main/java/com/epris/homepage/activity/corporate_project/domain/CorporateProject.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/domain/CorporateProject.java
@@ -2,9 +2,11 @@ package com.epris.homepage.activity.corporate_project.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CorporateProject {
     @Id
@@ -14,4 +16,10 @@ public class CorporateProject {
 
     @Column(name = "project_info", nullable = false, columnDefinition = "TEXT")
     private String projectInfo;
+
+
+    /* 프로젝트 정보 수정 */
+    public void update(String projectInfo){
+        this.projectInfo = projectInfo;
+    }
 }

--- a/src/main/java/com/epris/homepage/activity/corporate_project/domain/CorporateProjectImage.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/domain/CorporateProjectImage.java
@@ -2,6 +2,7 @@ package com.epris.homepage.activity.corporate_project.domain;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,5 +22,11 @@ public class CorporateProjectImage {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "corporate_project_id")
     private CorporateProject corporateProject;
+
+    @Builder
+    public  CorporateProjectImage(CorporateProject corporateProject, String projectImgUrl){
+        this.projectImgUrl = projectImgUrl;
+        this.corporateProject = corporateProject;
+    }
 
 }

--- a/src/main/java/com/epris/homepage/activity/corporate_project/dto/CorporateProjectRequestDto.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/dto/CorporateProjectRequestDto.java
@@ -1,0 +1,15 @@
+package com.epris.homepage.activity.corporate_project.dto;
+
+import com.epris.homepage.global.dto.ImageUrl;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class CorporateProjectRequestDto {
+    private String projectInfo;
+    List<ImageUrl> imageUrlList;
+    List<ImageUrl> imageUrlListToDelete;
+}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/dto/CorporateProjectResponseDto.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/dto/CorporateProjectResponseDto.java
@@ -1,0 +1,29 @@
+package com.epris.homepage.activity.corporate_project.dto;
+
+import com.epris.homepage.activity.corporate_project.domain.CorporateProject;
+import com.epris.homepage.activity.session.domain.Session;
+import com.epris.homepage.activity.session.dto.SessionResponseDto;
+import com.epris.homepage.global.dto.ImageInfo;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CorporateProjectResponseDto {
+    private Long projectId;
+    private String projectInfo;
+    private List<ImageInfo> imageList;
+
+    public static CorporateProjectResponseDto of(CorporateProject corporateProject, List<ImageInfo> imageList){
+        return CorporateProjectResponseDto.builder()
+                .projectId(corporateProject.getCorporateProjectId())
+                .projectInfo(corporateProject.getProjectInfo())
+                .imageList(imageList)
+                .build();
+    }
+}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectImageRespository.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectImageRespository.java
@@ -1,0 +1,11 @@
+package com.epris.homepage.activity.corporate_project.repository;
+
+import com.epris.homepage.activity.corporate_project.domain.CorporateProject;
+import com.epris.homepage.activity.corporate_project.domain.CorporateProjectImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CorporateProjectImageRespository extends JpaRepository<CorporateProjectImage, Long> {
+    List<CorporateProjectImage> findAllByCorporateProject(CorporateProject corporateProject);
+}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectLogoRespository.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectLogoRespository.java
@@ -1,9 +1,0 @@
-package com.epris.homepage.activity.corporate_project.repository;
-
-import com.epris.homepage.activity.corporate_project.domain.CorporateProjectImage;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
-
-public interface CorporateProjectLogoRespository extends JpaRepository<CorporateProjectImage, Long> {
-}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectRepository.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectRepository.java
@@ -1,0 +1,11 @@
+package com.epris.homepage.activity.corporate_project.repository;
+
+
+import com.epris.homepage.activity.corporate_project.domain.CorporateProject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface CorporateProjectRepository extends JpaRepository<CorporateProject, Long> {
+    CorporateProject findByCorporateProjectId(Long corporateProjectId);
+
+}

--- a/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
@@ -33,11 +33,12 @@ public class CorporateProjectService {
 
     private final CorporateProjectRepository corporateProjectRepository;
     private final CorporateProjectImageRespository corporateProjectImageRespository;
+    Long CORPORATE_PROJECT_ID = 1L;
 
     /* 협력 프로젝트 수정 */
     public ResponseEntity<CorporateProjectResponseDto> updateCorporateProject(CorporateProjectRequestDto requestDto) throws IOException {
         /* 1번 프로젝트에 대한 수정만 반복될 것임 */
-        CorporateProject updateCorporateProject = findById(1L);
+        CorporateProject updateCorporateProject = findById(CORPORATE_PROJECT_ID);
 
         /* 기존 이미지 삭제 */
         deleteCorporateProjectImageList(updateCorporateProject);
@@ -56,7 +57,7 @@ public class CorporateProjectService {
 
     /* 협력 프로젝트 조회 */
     public ResponseEntity<CorporateProjectResponseDto> findCorporateProject() {
-        CorporateProject corporateProject = findById(1L);
+        CorporateProject corporateProject = findById(CORPORATE_PROJECT_ID);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CorporateProjectResponseDto.of(corporateProject,
                         makeImageInfoDto(corporateProjectImageRespository.findAllByCorporateProject(corporateProject))));

--- a/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
@@ -6,10 +6,7 @@ import com.epris.homepage.activity.corporate_project.dto.CorporateProjectRequest
 import com.epris.homepage.activity.corporate_project.dto.CorporateProjectResponseDto;
 import com.epris.homepage.activity.corporate_project.repository.CorporateProjectImageRespository;
 import com.epris.homepage.activity.corporate_project.repository.CorporateProjectRepository;
-import com.epris.homepage.activity.session.domain.SessionImage;
 import com.epris.homepage.global.dto.ImageInfo;
-import com.epris.homepage.global.dto.ImageRequestDto;
-import com.epris.homepage.global.dto.ImageResponseDto;
 import com.epris.homepage.global.dto.ImageUrl;
 import com.epris.homepage.global.exception.CustomException;
 import com.epris.homepage.global.exception.ErrorCode;
@@ -55,6 +52,14 @@ public class CorporateProjectService {
                         makeImageInfoDto(corporateProjectImageRespository.findAllByCorporateProject(updateCorporateProject))));
 
 
+    }
+
+    /* 협력 프로젝트 조회 */
+    public ResponseEntity<CorporateProjectResponseDto> findCorporateProject() {
+        CorporateProject corporateProject = findById(1L);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CorporateProjectResponseDto.of(corporateProject,
+                        makeImageInfoDto(corporateProjectImageRespository.findAllByCorporateProject(corporateProject))));
     }
 
 

--- a/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/service/CorporateProjectService.java
@@ -1,18 +1,28 @@
 package com.epris.homepage.activity.corporate_project.service;
 
+import com.epris.homepage.activity.corporate_project.domain.CorporateProject;
 import com.epris.homepage.activity.corporate_project.domain.CorporateProjectImage;
-import com.epris.homepage.activity.corporate_project.repository.CorporateProjectLogoRespository;
+import com.epris.homepage.activity.corporate_project.dto.CorporateProjectRequestDto;
+import com.epris.homepage.activity.corporate_project.dto.CorporateProjectResponseDto;
+import com.epris.homepage.activity.corporate_project.repository.CorporateProjectImageRespository;
+import com.epris.homepage.activity.corporate_project.repository.CorporateProjectRepository;
+import com.epris.homepage.activity.session.domain.SessionImage;
+import com.epris.homepage.global.dto.ImageInfo;
 import com.epris.homepage.global.dto.ImageRequestDto;
 import com.epris.homepage.global.dto.ImageResponseDto;
+import com.epris.homepage.global.dto.ImageUrl;
+import com.epris.homepage.global.exception.CustomException;
+import com.epris.homepage.global.exception.ErrorCode;
 import com.epris.homepage.global.service.FileService;
+import com.epris.homepage.global.service.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import software.amazon.awssdk.services.s3.endpoints.internal.Value;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -21,29 +31,61 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CorporateProjectService {
 
-    private final CorporateProjectLogoRespository corporateProjectLogoRespository;
     private final FileService fileService;
-    /* 프로젝트 로고 업로드 */
-    public ResponseEntity<ImageResponseDto> uploadProjectLogo(ImageRequestDto requestDto) throws IOException {
-        /* 기존 이미지 삭제 */
-        List<CorporateProjectImage> oldImageList = corporateProjectLogoRespository.findAll();
-        deleteProjectLogo(oldImageList);
+    private final ImageService imageService;
 
-        /* 새로운 이미지 저장 */
+    private final CorporateProjectRepository corporateProjectRepository;
+    private final CorporateProjectImageRespository corporateProjectImageRespository;
+
+    /* 협력 프로젝트 수정 */
+    public ResponseEntity<CorporateProjectResponseDto> updateCorporateProject(CorporateProjectRequestDto requestDto) throws IOException {
+        /* 1번 프로젝트에 대한 수정만 반복될 것임 */
+        CorporateProject updateCorporateProject = findById(1L);
+
+        /* 기존 이미지 삭제 */
+        deleteCorporateProjectImageList(updateCorporateProject);
+        imageService.deleteImageList(requestDto.getImageUrlListToDelete());
+
+        /* 세션 업데이트 */
+        updateCorporateProject.update(requestDto.getProjectInfo());
+        saveImageList(updateCorporateProject,requestDto.getImageUrlList());
+
         return ResponseEntity.status(HttpStatus.OK)
-                .body(null);
+                .body(CorporateProjectResponseDto.of(updateCorporateProject,
+                        makeImageInfoDto(corporateProjectImageRespository.findAllByCorporateProject(updateCorporateProject))));
+
+
     }
 
 
-
-    /* 프로젝트 로고 삭제 */
-    public void deleteProjectLogo(List<CorporateProjectImage> projectImageList) throws IOException {
-        if(!projectImageList.isEmpty()){
-            for(CorporateProjectImage projectImage : projectImageList){
-                fileService.deleteImage(projectImage.getProjectImgUrl());
-                corporateProjectLogoRespository.delete(projectImage);
-            }
+    /* 협력 프로젝트의 모든 이미지 삭제 */
+    private void deleteCorporateProjectImageList(CorporateProject corporateProject) throws IOException {
+        List<CorporateProjectImage> corporateProjectImageList = corporateProjectImageRespository.findAllByCorporateProject(corporateProject);
+        for(CorporateProjectImage corporateProjectImage : corporateProjectImageList){
+            fileService.deleteImage(corporateProjectImage.getProjectImgUrl());
+            corporateProjectImageRespository.delete(corporateProjectImage);
         }
     }
 
+    /* Id 로 프로젝트 조회 */
+    public CorporateProject findById(Long id){
+        return corporateProjectRepository.findById(id)
+                .orElseThrow(()->new CustomException(ErrorCode.NO_CONTENT_EXIST));
+    }
+
+    /* 프로젝트의 새로운 이미지 저장 */
+    public void saveImageList(CorporateProject corporateProject, List<ImageUrl> imageUrlList){
+        for(ImageUrl imageUrl : imageUrlList){
+            corporateProjectImageRespository.save(new CorporateProjectImage(corporateProject,imageUrl.getImageUrl()));
+        }
+    }
+
+    /* imageInfo dto 생성 */
+    public List<ImageInfo> makeImageInfoDto(List<CorporateProjectImage> imageList){
+        List<ImageInfo> imageInfoList = new ArrayList<>();
+        for(CorporateProjectImage corporateProjectImage : imageList){
+            imageInfoList.add(ImageInfo.of(corporateProjectImage.getCorporateProjectImgId(), corporateProjectImage.getProjectImgUrl()));
+        }
+        return imageInfoList;
+    }
 }


### PR DESCRIPTION
# 구현 기능
- 협력 프로젝트 수정 기능
- 협력 프로젝트 조회 기능  




# 알림 사항
- 협력 프로젝트 자체는 항상 1개로 유지됨. 따라서 DB에 협력 프로젝트 1개를 넣어두고, 그 프로젝트에 대한 수정이 반복되도록 구현함.
  - 매번 요청이 들어올 때마다 새로운 프로젝트 객체를 생성해서 DB에 저장할까 생각도 했지만, 이 경우 내용의 변경이 없거나 아주 적더라도 기존 DB에 있던 협력 프로젝트 데이터를 모두 삭제하고 새로운 데이터를 저장하는 방법으로 구현해야 할 것 같았습니다. 혹시 다른 방법이 있을 것 같다면 코멘트 남겨 주세요!