### PR TITLE
fix : S3에서 이미지 삭제가 되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/epris/homepage/global/config/S3Config.java
+++ b/src/main/java/com/epris/homepage/global/config/S3Config.java
@@ -36,12 +36,13 @@ public class S3Config {
 
     @Bean
     public AmazonS3 amazonS3() {
-        AmazonS3 s3Builder = AmazonS3ClientBuilder.standard()
-                .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
-                .build();
-        return s3Builder;
-    }
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
 
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
 
 }

--- a/src/main/java/com/epris/homepage/global/controller/FileController.java
+++ b/src/main/java/com/epris/homepage/global/controller/FileController.java
@@ -2,14 +2,14 @@ package com.epris.homepage.global.controller;
 
 import com.epris.homepage.global.dto.FileRequestDto;
 import com.epris.homepage.global.dto.FileResponseDto;
+import com.epris.homepage.global.dto.ImageUrl;
 import com.epris.homepage.global.service.FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,5 +23,12 @@ public class FileController {
         String fileUrl = fileService.getPreSignedUrl(requestDto.getFileName());
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(FileResponseDto.of(fileUrl));
+    }
+
+    @DeleteMapping
+    public ResponseEntity deleteImage(@RequestBody ImageUrl imageUrl) throws IOException {
+        fileService.deleteImage(imageUrl.getImageUrl());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body("삭제 완료");
     }
 }


### PR DESCRIPTION
# 구현 기능
- S3 버킷에서 이미지 삭제가 제대로 작동되도록 수정.

# 문제 원인
- presigned url 을 통해 객체의 url 이 생성되고, 이것이 DB에 저장되는데 이 url 을 디코딩하여 이 객체에 접근하기 위한 키를 추출해야 했다. 
  - 하지만 이전에 진행했던 프로젝트의 경우, url 디코딩 과정이 필요하지 않았고 이 과정이 생략된 코드를 사용했다. 
  - 이 코드를 이번 프로젝트에서 사용하면서 발생했던 문제로, 객체 url 에서 키값을 찾을 때 디코딩하는 코드를 추가하여 해결하였다.