### PR TITLE
fix: 회원가입시 관리자 계정이 있는지 확인하는 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/admin/service/AdminService.java
+++ b/src/main/java/com/epris/homepage/admin/service/AdminService.java
@@ -29,7 +29,7 @@ public class AdminService {
     /* 관리자 계정 생성 */
     public String saveAdmin(SignupRequestDto requestDto){
         /* 관리자 계정이 있는지 확인 */
-        if(!existsById(1L)){
+        if(existsById(1L)){
             throw new CustomException(ErrorCode.ALREADY_EXIST);
         }
 


### PR DESCRIPTION
# 구현 사항
- 회원가입시 이미 관리자 계정이 있을 경우 에러코드를 응답하도록 수정하였습니다.

# Solved
- #32 