### PR TITLE
feat : 액세스 토큰 유효 기간 수정

### DIFF
--- a/src/main/java/com/epris/homepage/admin/service/AdminService.java
+++ b/src/main/java/com/epris/homepage/admin/service/AdminService.java
@@ -57,7 +57,7 @@ public class AdminService {
         - 액세스토큰: 30분
         - 리프레시토큰: 7일
         */
-        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofMinutes(30));
+        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofDays(7));
         String refreshToken = tokenProvider.generateRefreshToken(admin, Duration.ofDays(7));
 
         /* 리프레시 토큰 저장 */

--- a/src/main/java/com/epris/homepage/admin/service/TokenService.java
+++ b/src/main/java/com/epris/homepage/admin/service/TokenService.java
@@ -34,7 +34,7 @@ public class TokenService {
         Admin admin = findById(adminId);
 
         /* 액세스 토큰 재발급: 30분 */
-        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofMinutes(30));
+        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofDays(7));
 
         return TokenResponseDto.builder()
                 .accessToken(accessToken)


### PR DESCRIPTION
# 수정 사항
- 프론트의 api 연결기간 동안만 액세스 토큰의 유효기간을 7일로 연장해둠.
  - 연결 마감 후 토큰 유효기간을 다시 줄일 예정.