### PR TITLE
refactor : 로고 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/eprian/corporate_logo/repository/LogoRepository.java
+++ b/src/main/java/com/epris/homepage/eprian/corporate_logo/repository/LogoRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 public interface LogoRepository extends JpaRepository<CorporateLogo, Long> {
     List<CorporateLogo> findAllByLogoType(LogoType logoType);
-
+    CorporateLogo findByLogoImg(String logoImg);
+    Boolean existsByLogoImg(String logoImg);
 }


### PR DESCRIPTION
# 수정 사항
- 기존에 저장되어 있던 로고를 모두 삭제하는 것이 아니라 삭제해야 하는 로고만 삭제하도록 수정함.
  - 요청 dto의 url 중 기존 DB에 있는 url은 살리고, 없는 url은 DB에서 삭제함.
  - DB에 존재하지 않는 url은 새롭게 저장함.