### PR TITLE
refactor : 협력 프로젝트 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectImageRespository.java
+++ b/src/main/java/com/epris/homepage/activity/corporate_project/repository/CorporateProjectImageRespository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface CorporateProjectImageRespository extends JpaRepository<CorporateProjectImage, Long> {
     List<CorporateProjectImage> findAllByCorporateProject(CorporateProject corporateProject);
+    Boolean existsByProjectImgUrl(String projectImgUrl);
+    CorporateProjectImage findByProjectImgUrl(String projectImgUrl);
 }


### PR DESCRIPTION
# 수정 사항
- 기존에 저장되어 있던 이미지를 모두 삭제하는 것이 아니라 삭제해야 하는 이미지만 삭제하도록 수정함.
  - 요청 dto의 url 중 기존 DB에 있는 url은 살리고, 없는 url은 DB에서 삭제함.
  - DB에 존재하지 않는 url은 새롭게 저장함.