### PR TITLE
refactor : 세션 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/activity/session/domain/SessionImage.java
+++ b/src/main/java/com/epris/homepage/activity/session/domain/SessionImage.java
@@ -16,7 +16,7 @@ public class SessionImage {
     private Long sessionImgId;
 
     @Column(name = "session_img_url", updatable = false)
-    private String SessionImgUrl;
+    private String sessionImgUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "session_id")
@@ -24,7 +24,7 @@ public class SessionImage {
 
     @Builder
     public SessionImage(String sessionImgUrl, Session session){
-        this.SessionImgUrl = sessionImgUrl;
+        this.sessionImgUrl = sessionImgUrl;
         this.session = session;
     }
 }

--- a/src/main/java/com/epris/homepage/activity/session/respository/SessionImageRepository.java
+++ b/src/main/java/com/epris/homepage/activity/session/respository/SessionImageRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 
 public interface SessionImageRepository extends JpaRepository<SessionImage, Long> {
     List<SessionImage> findAllBySession(Session session);
+    Boolean existsBySessionImgUrl(String SessionImgUrl);
+    SessionImage findBySessionImgUrl(String SessionImgUrl);
 }


### PR DESCRIPTION
# 수정 사항
- 기존에 저장되어 있던 이미지를 모두 삭제하는 것이 아니라 삭제해야 하는 이미지만 삭제하도록 수정함.
  - 요청 dto의 url 중 기존 DB에 있는 url은 살리고, 없는 url은 DB에서 삭제함.
  - DB에 존재하지 않는 url은 새롭게 저장함.