### PR TITLE
feat : presigned url 발급 시 파일 이름을 이용하여 고유

### DIFF
--- a/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                     /* 회원가입, 로그인, 액세스토큰 재발급, GET요청은 항상 접근 가능 */
                     requests.requestMatchers("admin/signup","admin/login","token").permitAll();
                     requests.requestMatchers(HttpMethod.GET).permitAll();
+                    requests.requestMatchers(HttpMethod.POST).permitAll();
                     /* 다른 모든 요청은 막기 */
                     requests.anyRequest().authenticated();
                 })

--- a/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
@@ -52,7 +52,6 @@ public class SecurityConfig {
                     /* 회원가입, 로그인, 액세스토큰 재발급, GET요청은 항상 접근 가능 */
                     requests.requestMatchers("admin/signup","admin/login","token").permitAll();
                     requests.requestMatchers(HttpMethod.GET).permitAll();
-                    requests.requestMatchers(HttpMethod.POST).permitAll();
                     /* 다른 모든 요청은 막기 */
                     requests.anyRequest().authenticated();
                 })

--- a/src/main/java/com/epris/homepage/global/service/FileService.java
+++ b/src/main/java/com/epris/homepage/global/service/FileService.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 
 @Service
@@ -41,7 +42,8 @@ public class FileService {
 
     /* presigned url 발급 */
     public String getPreSignedUrl(String fileName) throws Exception {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucket, fileName);
+        String uniqueFileName = createPath(fileName);
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucket, uniqueFileName);
         URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
 
         return url.toString();
@@ -90,5 +92,14 @@ public class FileService {
         String path = urlObj.getPath();
         /* url 디코딩 */
         return URLDecoder.decode(path.substring(path.lastIndexOf('/') + 1), StandardCharsets.UTF_8);
+    }
+
+    private String createFileId() {
+        return UUID.randomUUID().toString();
+    }
+
+    private String createPath(String fileName) {
+        String fileId = createFileId();
+        return String.format("%s", fileId + fileName);
     }
 }


### PR DESCRIPTION
# 수정 사항
- presigned url 발급 시 전달받은 fileName으로 고유한 파일의 key를 생성하여 url을 발급받도록 수정
  - 동일한 파일 이름을 전달받더라도 고유한 key를 생성하여 버킷에 올라가기 때문에 동일한 파일명으로 요청을 보내어도 기존의 파일이 교체되지 않음.