### PR TITLE
fix: 기수 정보 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/generation/class_info/service/ClassInfoService.java
+++ b/src/main/java/com/epris/homepage/generation/class_info/service/ClassInfoService.java
@@ -28,9 +28,10 @@ public class ClassInfoService {
         /* 기수 정보 가져오기 */
         ClassInfo classInfo = findById(1L);
 
-        /* 기존 이미지 삭제 */
-        String adminImg = classInfo.getAdminImg();
-        fileService.deleteImage(adminImg);
+        /* 기존에 저장되어있던 이미지와 요청 dto의 url이 다를 경우, 기존 url 삭제 */
+        if(!classInfo.getAdminImg().isEmpty() && !classInfo.getAdminImg().equals(requestDto.getAdminImg())) {
+            fileService.deleteImage(classInfo.getAdminImg());
+        }
 
         /* 기수 정보 업데이트 */
         classInfo.updateClassinfo(requestDto.getNum(), requestDto.getPhoneNum(), requestDto.getPhoneNumInfo(), requestDto.getEmail(),


### PR DESCRIPTION
# 구현 기능
- 기수 정보 업데이트시 기존에 저장되어있던 이미지와 요청 dto의 url이 다를 경우에만 기존 url을 삭제하도록 수정하였습니다.

# Solved
- #14 