### PR TITLE
fix: 모집 정보 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/epris/homepage/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/epris/homepage/recruitment/service/RecruitmentService.java
@@ -27,11 +27,15 @@ public class RecruitmentService {
         /* 모집 정보 가져오기 */
         Recruitment recruitment = findById(1L);
 
-        /* 기존 파일 삭제 */
-        String doc = recruitment.getDoc();
-        String poster = recruitment.getPoster();
-        fileService.deleteImage(doc);
-        fileService.deleteImage(poster);
+        /* 기존에 저장되어있던 문서와 요청 dto의 url이 다를 경우, 기존 url 삭제 */
+        if(!recruitment.getDoc().isEmpty() && !recruitment.getDoc().equals(requestDto.getDoc())){
+            fileService.deleteImage(requestDto.getDoc());
+        }
+
+        /* 기존에 저장되어있던 포스터와 요청 dto의 url이 다를 경우, 기존 url 삭제 */
+        if(!recruitment.getPoster().isEmpty() && !recruitment.getPoster().equals(recruitment.getPoster())){
+            fileService.deleteImage(requestDto.getPoster());
+        }
 
         /* 모집 정보 업데이트 */
         recruitment.updateRecruitment(requestDto.getDoc(), requestDto.getPoster(), requestDto.getNotice(),

--- a/src/main/java/com/epris/homepage/recruitment/service/RecruitmentService.java
+++ b/src/main/java/com/epris/homepage/recruitment/service/RecruitmentService.java
@@ -29,12 +29,12 @@ public class RecruitmentService {
 
         /* 기존에 저장되어있던 문서와 요청 dto의 url이 다를 경우, 기존 url 삭제 */
         if(!recruitment.getDoc().isEmpty() && !recruitment.getDoc().equals(requestDto.getDoc())){
-            fileService.deleteImage(requestDto.getDoc());
+            fileService.deleteImage(recruitment.getDoc());
         }
 
         /* 기존에 저장되어있던 포스터와 요청 dto의 url이 다를 경우, 기존 url 삭제 */
-        if(!recruitment.getPoster().isEmpty() && !recruitment.getPoster().equals(recruitment.getPoster())){
-            fileService.deleteImage(requestDto.getPoster());
+        if(!recruitment.getPoster().isEmpty() && !recruitment.getPoster().equals(requestDto.getPoster())){
+            fileService.deleteImage(recruitment.getPoster());
         }
 
         /* 모집 정보 업데이트 */


### PR DESCRIPTION
# 구현 기능
- 모집 정보 업데이트시 기존에 저장되어있던 문서/포스터와 요청 dto의 url이 다를 경우에만 기존 url을 삭제하도록 수정하였습니다.

# Solved
- #17 