### PR TITLE
feat: 토큰 만료 Exception 설정

### DIFF
--- a/src/main/java/com/epris/homepage/admin/service/AdminService.java
+++ b/src/main/java/com/epris/homepage/admin/service/AdminService.java
@@ -57,8 +57,8 @@ public class AdminService {
         - 액세스토큰: 30분
         - 리프레시토큰: 7일
         */
-        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofDays(7));
-        String refreshToken = tokenProvider.generateRefreshToken(admin, Duration.ofDays(7));
+        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofMinutes(30));
+        String refreshToken = tokenProvider.generateRefreshToken(admin, Duration.ofHours(1));
 
         /* 리프레시 토큰 저장 */
         tokenService.saveRefreshToken(refreshToken, admin.getAdminId());

--- a/src/main/java/com/epris/homepage/admin/service/TokenService.java
+++ b/src/main/java/com/epris/homepage/admin/service/TokenService.java
@@ -26,7 +26,7 @@ public class TokenService {
     public TokenResponseDto createNewAccessToken(String refreshToken) {
         /* 유효한 토큰인지 확인 */
         if(!tokenProvider.validateToken(refreshToken)){
-            throw new CustomException(ErrorCode.INVALID_TOKEN);
+            throw new CustomException(ErrorCode.EXPIRED_TOKEN);
         }
 
         /* 유효하다면 해당 토큰으로 관리자 ID를 찾아 관리자 객체 가져오기 */

--- a/src/main/java/com/epris/homepage/admin/service/TokenService.java
+++ b/src/main/java/com/epris/homepage/admin/service/TokenService.java
@@ -34,7 +34,7 @@ public class TokenService {
         Admin admin = findById(adminId);
 
         /* 액세스 토큰 재발급: 30분 */
-        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofDays(7));
+        String accessToken = tokenProvider.generateAccessToken(admin, Duration.ofMinutes(30));
 
         return TokenResponseDto.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
+++ b/src/main/java/com/epris/homepage/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.epris.homepage.global.config;
 
+import com.epris.homepage.global.filter.JwtAuthenticationFilter;
+import com.epris.homepage.global.filter.JwtExceptionFilter;
 import com.epris.homepage.global.jwt.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -59,7 +61,8 @@ public class SecurityConfig {
                 .sessionManagement(
                         sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                .addFilterBefore(new TokenAuthFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/epris/homepage/global/exception/ErrorCode.java
+++ b/src/main/java/com/epris/homepage/global/exception/ErrorCode.java
@@ -25,7 +25,7 @@ public enum ErrorCode {
     ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 관리자 계정이 존재합니다."),
 
     /* JWT */
-    INVALID_TOKEN(HttpStatus.BAD_REQUEST,"유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"만료된 토큰입니다."),
 
     /* member */
     INVALID_NUM(HttpStatus.BAD_REQUEST,"존재하지 않는 기수입니다.")

--- a/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.epris.homepage.global.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증되지 않은 접근입니다.");
+    }
+}

--- a/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationFilter.java
@@ -31,11 +31,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String token = getAccessToken(authorizationHeader);
 
         if(!ObjectUtils.isEmpty(token)){
+            /* 토큰이 만료된 경우 Exception 던지기 */
             if(tokenProvider.isTokenExpired(token)){
                 throw new JwtException("accessToken is expired");
             }
 
-            /* 가져온 토큰이 유효한지 확인하고, 유효하다면 인증정보 설정 */
+            /* 토큰이 유효한지 확인하고, 유효하다면 인증정보 설정 */
             if(tokenProvider.validateToken(token)){
                 Authentication authentication = tokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/epris/homepage/global/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
-package com.epris.homepage.global.config;
+package com.epris.homepage.global.filter;
 
 import com.epris.homepage.global.jwt.TokenProvider;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -8,12 +9,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
-public class TokenAuthFilter extends OncePerRequestFilter {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenProvider tokenProvider;
 
     @Override
@@ -26,10 +30,16 @@ public class TokenAuthFilter extends OncePerRequestFilter {
         /* 가져온 값에서 Bearer 제거 */
         String token = getAccessToken(authorizationHeader);
 
-        /* 가져온 토큰이 유효한지 확인하고, 유효하다면 인증정보 설정 */
-        if(tokenProvider.validateToken(token)){
-            Authentication authentication = tokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+        if(!ObjectUtils.isEmpty(token)){
+            if(tokenProvider.isTokenExpired(token)){
+                throw new JwtException("accessToken is expired");
+            }
+
+            /* 가져온 토큰이 유효한지 확인하고, 유효하다면 인증정보 설정 */
+            if(tokenProvider.validateToken(token)){
+                Authentication authentication = tokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/epris/homepage/global/filter/JwtExceptionFilter.java
+++ b/src/main/java/com/epris/homepage/global/filter/JwtExceptionFilter.java
@@ -1,0 +1,35 @@
+package com.epris.homepage.global.filter;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain) throws ServletException, IOException {
+        try {
+            chain.doFilter(req, res);
+        } catch (JwtException ex) {
+            setErrorResponse(HttpStatus.UNAUTHORIZED, res, ex);
+        }
+    }
+
+    public void setErrorResponse(HttpStatus status, HttpServletResponse res, Throwable ex) throws IOException {
+        res.setStatus(status.value());
+        res.setContentType("application/json; charset=UTF-8");
+
+        JwtExceptionResponse jwtExceptionResponse = new JwtExceptionResponse(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN","만료된 토큰입니다.");
+        res.getWriter().write(jwtExceptionResponse.convertToJson());
+    }
+}

--- a/src/main/java/com/epris/homepage/global/filter/JwtExceptionResponse.java
+++ b/src/main/java/com/epris/homepage/global/filter/JwtExceptionResponse.java
@@ -1,0 +1,22 @@
+package com.epris.homepage.global.filter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+@Setter
+public class JwtExceptionResponse {
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    public String convertToJson() throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(this);
+    }
+}

--- a/src/main/java/com/epris/homepage/global/jwt/TokenProvider.java
+++ b/src/main/java/com/epris/homepage/global/jwt/TokenProvider.java
@@ -54,6 +54,12 @@ public class TokenProvider {
                 .compact();
     }
 
+    /* 토큰이 만료됐는지 확인 */
+    public boolean isTokenExpired(String token) {
+        final Date expiration = getExpirationDate(token);
+        return expiration.before(new Date());
+    }
+
     /* JWT 토큰 유효성 검증 */
     public boolean validateToken(String token){
         try{
@@ -85,5 +91,10 @@ public class TokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    /* 토큰의 만료 날짜 가져오기 */
+    public Date getExpirationDate(String token){
+        return getClaims(token).getExpiration();
     }
 }


### PR DESCRIPTION
# 구현 기능
- Security Filter단에서 발생하는 Exception 처리 설정
- 액세스 토큰, 리프레시 토큰 만료시 Unauthorized 에러 처리
- 프론트 로그인 개발을 위한 토큰 만료 시간 변경 (액세스 토큰: 30분, 리프레시 토큰: 1시간)

# 알림 사항
- 실제 배포시 리프레시 토큰 만료시간 7일로 변경하기!

# Solved
- #23 