### PR TITLE
fix : S3 내의 파일정 삭제되도록 수

### DIFF
--- a/src/main/java/com/epris/homepage/eprian/corporate_logo/service/LogoService.java
+++ b/src/main/java/com/epris/homepage/eprian/corporate_logo/service/LogoService.java
@@ -45,7 +45,7 @@ public class LogoService {
             }
         }
         /* 기존 로고 삭제 */
-        if(!deleteLogoList.isEmpty())deleteLogo(deleteLogoList);
+        if(!deleteLogoList.isEmpty()) deleteLogo(deleteLogoList);
 
         return findLogoListByType(type);
     }
@@ -63,7 +63,7 @@ public class LogoService {
     /* 로고 삭제 */
     public void deleteLogo(List<CorporateLogo> logoList) throws IOException {
         for(CorporateLogo corporateLogo:logoList){
-            //fileService.deleteImage(corporateLogo.getLogoImg());
+            fileService.deleteImage(corporateLogo.getLogoImg());
             logoRepository.delete(corporateLogo);
         }
     }


### PR DESCRIPTION
## 수정 사항
- 이미지 삭제 시 DB와 S3에서 모두 삭제되어야 하는데, 기존 코드에 실수로 주석 처리되어 있던 부분을 지움.