### PR TITLE
refactor : 운영진 목록 조회 순서 변경

### DIFF
--- a/src/main/java/com/epris/homepage/eprian/member/service/MemberService.java
+++ b/src/main/java/com/epris/homepage/eprian/member/service/MemberService.java
@@ -79,8 +79,8 @@ public class MemberService {
         List<MemberResponseDto> responseDtoList = new ArrayList<>();
         responseDtoList.addAll(findMemberByPosition("학회장").stream().map(MemberResponseDto::of).collect(Collectors.toList()));
         responseDtoList.addAll(findMemberByPosition("기획부장").stream().map(MemberResponseDto::of).collect(Collectors.toList()));
-        responseDtoList.addAll(findMemberByPosition("홍보부장").stream().map(MemberResponseDto::of).collect(Collectors.toList()));
         responseDtoList.addAll(findMemberByPosition("운영부장").stream().map(MemberResponseDto::of).collect(Collectors.toList()));
+        responseDtoList.addAll(findMemberByPosition("홍보부장").stream().map(MemberResponseDto::of).collect(Collectors.toList()));
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(responseDtoList);


### PR DESCRIPTION
## 변경 사항
- 운영진 학회원 목록 조회 시 학회장 -> 기획부장 -> 운영부장 -> 홍보부장 순으로 반환되도록 수정함.